### PR TITLE
Fixes GetStreamUriRequest, log_switch

### DIFF
--- a/lib/ruby_onvif_client/media/get_stream_uri.rb
+++ b/lib/ruby_onvif_client/media/get_stream_uri.rb
@@ -10,7 +10,7 @@ module ONVIF
             #       transport: {
             #           protocol: 'UDP', //'UDP', 'TCP', 'RTSP', 'HTTP'
             #           tunnel:{
-            #               protocol: 'TCP', //'UDP', 'TCP', 'RTSP', 'HTTP'           
+            #               protocol: 'TCP', //'UDP', 'TCP', 'RTSP', 'HTTP'
             #           }
             #       }
             #    }
@@ -21,12 +21,12 @@ module ONVIF
                 message.body =  ->(xml) do
                     xml.wsdl(:GetStreamUri) do
                         xml.wsdl(:StreamSetup) do
-                            xml.sch :Stream, options[:stream_setup][:stream]
+                            xml.sch :StreamType, options[:stream_setup][:stream_type]
                             xml.sch :Transport do
                                 xml.sch :Protocol, options[:stream_setup][:transport][:protocol]
                                 xml.sch :Tunnel do
                                     tunnel = options[:stream_setup][:transport][:tunnel]
-                                    unless tunnel.nil?
+                                    unless tunnel.nil? || tunnel.empty?
                                         xml.sch :Protocol,options[:stream_setup][:transport][:tunnel][:protocol]
                                         xml.sch :Tunnel,options[:stream_setup][:transport][:tunnel][:tunnel]
                                     end

--- a/lib/ruby_onvif_client/media/get_stream_uri.rb
+++ b/lib/ruby_onvif_client/media/get_stream_uri.rb
@@ -24,12 +24,13 @@ module ONVIF
                             xml.sch :StreamType, options[:stream_setup][:stream_type]
                             xml.sch :Transport do
                                 xml.sch :Protocol, options[:stream_setup][:transport][:protocol]
-                                xml.sch :Tunnel do
-                                    tunnel = options[:stream_setup][:transport][:tunnel]
-                                    unless tunnel.nil? || tunnel.empty?
-                                        xml.sch :Protocol,options[:stream_setup][:transport][:tunnel][:protocol]
-                                        xml.sch :Tunnel,options[:stream_setup][:transport][:tunnel][:tunnel]
-                                    end
+
+                                tunnel = options[:stream_setup][:transport][:tunnel]
+                                unless tunnel.nil? || tunnel.empty?
+                                  xml.sch :Tunnel do
+                                    xml.sch :Protocol, options[:stream_setup][:transport][:tunnel][:protocol]
+                                    xml.sch :Tunnel, options[:stream_setup][:transport][:tunnel][:tunnel]
+                                  end
                                 end
                             end
                         end

--- a/ruby-onvif-client.gemspec
+++ b/ruby-onvif-client.gemspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 Gem::Specification.new do |s|
     s.name        = 'ruby_onvif_client'
     s.version     = '0.1.6'
@@ -11,10 +12,10 @@ Gem::Specification.new do |s|
     s.homepage    = 'http://dreamcoder.info'
 
     s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
+    s.add_dependency 'log_switch', '~> 0.4'
     s.add_dependency 'em_ws_discovery'
     s.add_dependency 'em-http-request'
     s.add_dependency 'em-http-server'
     s.add_dependency 'activesupport'
     s.add_dependency 'akami'
 end
-


### PR DESCRIPTION
Hello! I have two minor improvements.
1. [log_switch](https://github.com/turboladen/log_switch) 1.0 introduced breaking changes, so I've pinned the gemspec on 0.4 (the last working version).
2. In trying to get stream URIs from some Avigilon devices, I noticed a discrepency between this gem and the ONVIF spec.
   - The [Media Service Spec (pdf)](http://www.onvif.org/specs/srv/media/ONVIF-Media-Service-Spec-v210.pdf) uses `StreamType` instead of `Stream` for the `StreamSetup` element of a `GetStreamUriRequest`.
   - Sending an empty `Tunnel` element actually breaks the request. So my changes omit that element if it has no contents.

Thanks!
